### PR TITLE
Updated docker-compose tag to match docker hub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   butler-app-duplicator:
-    image: ptarmiganlabs/butler-app-duplicator:3.0.0
+    image: ptarmiganlabs/butler-app-duplicator:v3.0.0
     restart: always
     container_name: butler-app-duplicator
     ports:


### PR DESCRIPTION
The docker-compose.yml is referencing tag "3.0.0" but the actual tag in Docker Hub is "v3.0.0"